### PR TITLE
fix: callback not firing on both platforms

### DIFF
--- a/src/urlhandler.android.ts
+++ b/src/urlhandler.android.ts
@@ -1,6 +1,11 @@
 import { AndroidActivityEventData, AndroidActivityNewIntentEventData, AndroidApplication, android as andApp } from '@nativescript/core/application';
-import { _handleURL, extractAppURL } from './urlhandler.common';
-export { handleOpenURL } from './urlhandler.common';
+import { _handleOpenURL, _handleURL, extractAppURL } from './urlhandler.common';
+import { UrlHandlerCallback } from './urlhandler';
+export { _handleOpenURL } from './urlhandler.common';
+
+export function handleOpenURL(handler: UrlHandlerCallback): void {
+    _handleOpenURL(handler);
+}
 
 export function handleIntent(intent: android.content.Intent, args?) {
     const data = intent.getData();

--- a/src/urlhandler.common.ts
+++ b/src/urlhandler.common.ts
@@ -31,7 +31,7 @@ export function extractAppURL(urlParam: any): AppURL {
     }
 }
 
-export function handleOpenURL(handler: UrlHandlerCallback): void {
+export function _handleOpenURL(handler: UrlHandlerCallback): void {
     URL_HANDLER_CB = handler;
 }
 
@@ -43,11 +43,11 @@ export function getCallback(): UrlHandlerCallback {
     }
     return URL_HANDLER_CB;
 }
+
 export function _handleURL(appURL, args?) {
     if (!URL_HANDLER_CB) {
         console.error('No callback provided. Please ensure that you called "handleOpenURL" during application init!');
     } else {
         URL_HANDLER_CB(appURL, args);
     }
-
 }

--- a/src/urlhandler.ios.ts
+++ b/src/urlhandler.ios.ts
@@ -1,12 +1,16 @@
-import { _handleURL, extractAppURL } from './urlhandler.common';
+import { _handleOpenURL, _handleURL, extractAppURL } from './urlhandler.common';
 import { getAppDelegate } from './getappdelegate';
-export { handleOpenURL } from './urlhandler.common';
+import { UrlHandlerCallback } from './urlhandler';
+
+export function handleOpenURL(handler: UrlHandlerCallback): void {
+    _handleOpenURL(handler);
+}
 
 export const appDelegate = getAppDelegate();
 
 function enableMultipleOverridesFor(classRef, methodName, nextImplementation) {
     const currentImplementation = classRef.prototype[methodName];
-    classRef.prototype[methodName] = function () {
+    classRef.prototype[methodName] = function() {
         const result = currentImplementation && currentImplementation.apply(currentImplementation, Array.from(arguments));
         return nextImplementation.apply(nextImplementation, Array.from(arguments).concat([result]));
     };
@@ -15,7 +19,7 @@ function enableMultipleOverridesFor(classRef, methodName, nextImplementation) {
 enableMultipleOverridesFor(
     appDelegate,
     'applicationOpenURLOptions',
-    function (
+    function(
         application: UIApplication,
         url: NSURL,
         options: any
@@ -40,7 +44,7 @@ enableMultipleOverridesFor(
 enableMultipleOverridesFor(
     appDelegate,
     'applicationContinueUserActivityRestorationHandler',
-    function (
+    function(
         application: UIApplication,
         userActivity: NSUserActivity,
         restorationHandler


### PR DESCRIPTION
Fix the callback not firing on iOS & Android platform.

The issue is `handleOpenURL` being imported from `.common.js` instead of platform specific file. That one creates an issue whether the initialisation of the library is not invoked.

We renamed the `handleOpenURL` to `_handleOpenURL` on `.common.js`. That makes the correct module to be initialised on runtime.